### PR TITLE
fix(layout): prevent playlist label column drift

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -18,7 +18,10 @@
   align-items: center;
   display: flex;
   justify-content: flex-end;
+  justify-self: end;
+  max-width: 100%;
   min-width: 0;
+  width: auto;
 }
 
 .spicetify-playlist-labels-header-placeholder {

--- a/src/components/PlaylistLabelsContainer.tsx
+++ b/src/components/PlaylistLabelsContainer.tsx
@@ -225,13 +225,7 @@ export const PlaylistLabelsContainer: React.FC<
   const shouldShowOverflowButton = hasOverflow && canRenderOverflowButton;
 
   return (
-    <div
-      className={CSS_CLASSES.LABELS_CONTAINER}
-      style={{
-        width: "100%",
-        maxWidth: "100%",
-      }}
-    >
+    <div className={CSS_CLASSES.LABELS_CONTAINER}>
       {displayedData.map((data) => (
         <PlaylistLabel
           key={data.uri || "liked-tracks"}

--- a/src/services/LayoutManager.ts
+++ b/src/services/LayoutManager.ts
@@ -1,4 +1,4 @@
-import { CONFIG } from "../constants";
+import { CONFIG, CSS_CLASSES } from "../constants";
 import { appState } from "../state/AppState";
 import { updateCSSVariable } from "../utils/dom";
 
@@ -36,7 +36,11 @@ export class LayoutManager {
       ".main-trackList-trackListRowGrid",
     );
     for (const element of gridElements) {
-      (element as HTMLElement).style.removeProperty("grid-template-columns");
+      const row = element as HTMLElement;
+      row.style.removeProperty("grid-template-columns");
+      for (const child of Array.from(row.children) as HTMLElement[]) {
+        child.style.removeProperty("grid-column");
+      }
     }
   }
 
@@ -163,7 +167,7 @@ export class LayoutManager {
       index,
       width: this.parsePixelValue(column),
     }));
-    const rowChildren = Array.from(sampleRow.children) as HTMLElement[];
+    const rowChildren = this.getNativeRowChildren(sampleRow);
 
     const donorColumns = parsedColumns
       .slice(1, -1)
@@ -204,7 +208,17 @@ export class LayoutManager {
       return null;
     }
 
-    return [...rebalancedWidths, `${labelColumnWidth}px`, lastColumn];
+    return [
+      ...rebalancedWidths,
+      `minmax(0, ${labelColumnWidth}px)`,
+      lastColumn,
+    ];
+  }
+
+  private getNativeRowChildren(row: HTMLElement): HTMLElement[] {
+    return Array.from(row.children).filter(
+      (child) => !child.classList.contains(CSS_CLASSES.LABEL_CONTAINER),
+    ) as HTMLElement[];
   }
 
   private getGridItemMinimumWidth(element: HTMLElement | undefined): number {


### PR DESCRIPTION
## Summary
- prevent the injected playlist-label grid cell from participating in native column measurements
- let the label cell align to the end without forcing the inner label container to fill the column
- clear stale grid-column overrides when recalculating tracklist layout

This cherry-picks the source fix from D3SOX/spicetify-playlist-labels@a3838fd5c85038a1979c9d7b26a592d7082b1c6c with attribution preserved in the commit author. This PR intentionally leaves dist unchanged; the PR build workflow generates a build artifact, and release automation handles committed dist updates.

Fixes #18

## Validation
- npm run type-check
- npx prettier --check src/app.css src/components/PlaylistLabelsContainer.tsx src/services/LayoutManager.ts
- git diff --check origin/main...HEAD
- npm run build:ci